### PR TITLE
🔒 Security: Replace plain text passwords with bcrypt hashing

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -41,7 +41,7 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 jsonwebtoken = "9.3.1"           # JWT creation & validation
 casbin = "2.10.1"                # RBAC authorization system  
 chrono = { version = "0.4.41", features = ["serde"] }  # Time handling
-bcrypt = "0.15"                  # Password hashing
+bcrypt = "0.17.0"                # Password hashing
 async-trait = "0.1.88"          # For async traits
 
 

--- a/backend/src/auth_handlers.rs
+++ b/backend/src/auth_handlers.rs
@@ -4,11 +4,49 @@ use axum::{
     response::Json,
 };
 use serde::{Deserialize, Serialize};
+use bcrypt::{hash, verify, BcryptError};
 
 use crate::api::handlers::ApiResponse;
 use crate::api::routes::AppState;
-use crate::auth::{create_jwt_token, JwtKeys, Claims};
-use crate::rbac::RbacEnforcer;
+use crate::auth::{create_jwt_token, Claims};
+
+/// Authentication errors
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("Password hashing failed")]
+    HashingFailed(#[from] BcryptError),
+    #[error("Invalid credentials")]
+    InvalidCredentials,
+    #[error("User not found")]
+    UserNotFound,
+}
+
+impl From<AuthError> for StatusCode {
+    fn from(err: AuthError) -> Self {
+        match err {
+            AuthError::HashingFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            AuthError::InvalidCredentials | AuthError::UserNotFound => StatusCode::UNAUTHORIZED,
+        }
+    }
+}
+
+/// Hash a password using bcrypt with async support
+pub async fn hash_password(password: &str, cost: u32) -> Result<String, BcryptError> {
+    let password = password.to_string();
+    tokio::task::spawn_blocking(move || hash(password, cost))
+        .await
+        .map_err(|_| BcryptError::InvalidCost(cost.to_string()))?
+}
+
+/// Verify a password against a bcrypt hash with async support
+pub async fn verify_password(password: &str, hash: &str) -> Result<bool, BcryptError> {
+    let password = password.to_string();
+    let hash = hash.to_string();
+    let hash_clone = hash.clone();
+    tokio::task::spawn_blocking(move || verify(password, &hash))
+        .await
+        .map_err(|_| BcryptError::InvalidHash(hash_clone))?
+}
 
 /// Login request payload
 #[derive(Debug, Deserialize)]
@@ -35,39 +73,41 @@ pub struct UserInfo {
     pub permissions: std::collections::HashMap<String, Vec<String>>,
 }
 
-/// Simple user database (in production, this would be a real database)
-/// For demo purposes, we'll have some hardcoded users
+/// User struct with secure bcrypt password hashing
+#[derive(Debug)]
 struct User {
     pub id: String,
     pub username: String,
-    pub password_hash: String, // In production, this would be bcrypt hashed
+    pub password_hash: String, // bcrypt hashed password
 }
 
 impl User {
-    fn new(id: &str, username: &str, password: &str) -> Self {
-        // In production, you'd hash the password with bcrypt
-        // For demo, we'll use plain text (NOT SECURE!)
-        Self {
+    /// Create a new user with bcrypt hashed password
+    async fn new(id: &str, username: &str, password: &str, cost: u32) -> Result<Self, AuthError> {
+        let password_hash = hash_password(password, cost).await?;
+        Ok(Self {
             id: id.to_string(),
             username: username.to_string(),
-            password_hash: password.to_string(), // WARNING: Not hashed for demo!
-        }
+            password_hash,
+        })
     }
     
-    fn verify_password(&self, password: &str) -> bool {
-        // In production, use bcrypt::verify
-        self.password_hash == password
+    /// Verify password against bcrypt hash
+    async fn verify_password(&self, password: &str) -> Result<bool, AuthError> {
+        verify_password(password, &self.password_hash)
+            .await
+            .map_err(AuthError::HashingFailed)
     }
 }
 
-/// Get demo users (in production, this would query a database)
-fn get_demo_users() -> Vec<User> {
-    vec![
-        User::new("admin", "admin", "admin123"),
-        User::new("user", "user", "user123"),
-        User::new("demo", "demo", "demo123"),
-        User::new("developer", "developer", "password123"),
-    ]
+/// Get demo users with bcrypt hashed passwords (in production, this would query a database)
+async fn get_demo_users(cost: u32) -> Result<Vec<User>, AuthError> {
+    Ok(vec![
+        User::new("admin", "admin", "admin123", cost).await?,
+        User::new("user", "user", "user123", cost).await?,
+        User::new("demo", "demo", "demo123", cost).await?,
+        User::new("developer", "developer", "password123", cost).await?,
+    ])
 }
 
 /// Login endpoint - authenticates user and returns JWT token
@@ -75,28 +115,43 @@ pub async fn login(
     State(app_state): State<AppState>,
     Json(login_req): Json<LoginRequest>,
 ) -> Result<Json<ApiResponse<LoginResponse>>, StatusCode> {
-    println!("🔐 Login attempt for user: {}", login_req.username);
+    tracing::info!("🔐 Login attempt for user: {}", login_req.username);
 
     // Check if authentication is enabled
     if !app_state.jwt_keys.config.enabled {
-        println!("⚠️  Authentication is disabled");
+        tracing::warn!("⚠️  Authentication is disabled");
         return Err(StatusCode::SERVICE_UNAVAILABLE);
     }
 
     // Find user in our demo database
-    let users = get_demo_users();
+    let users = get_demo_users(app_state.jwt_keys.config.password_hash_cost)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to load demo users: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    
     let user = users
         .iter()
         .find(|u| u.username == login_req.username)
         .ok_or_else(|| {
-            println!("❌ User '{}' not found", login_req.username);
+            tracing::info!("❌ User '{}' not found", login_req.username);
             StatusCode::UNAUTHORIZED
         })?;
 
-    // Verify password
-    if !user.verify_password(&login_req.password) {
-        println!("❌ Invalid password for user '{}'", login_req.username);
-        return Err(StatusCode::UNAUTHORIZED);
+    // Verify password using bcrypt
+    match user.verify_password(&login_req.password).await {
+        Ok(true) => {
+            tracing::info!("✅ Password verification successful for user: {}", user.username);
+        },
+        Ok(false) => {
+            tracing::info!("❌ Invalid password for user '{}'", login_req.username);
+            return Err(StatusCode::UNAUTHORIZED);
+        },
+        Err(e) => {
+            tracing::error!("Password verification failed: {}", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
     }
 
     // Create JWT token
@@ -106,11 +161,11 @@ pub async fn login(
         &app_state.jwt_keys.config,
     )
     .map_err(|e| {
-        println!("❌ Failed to create JWT token: {}", e);
+        tracing::error!("❌ Failed to create JWT token: {}", e);
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
 
-    println!("✅ Login successful for user: {}", user.username);
+    tracing::info!("✅ Login successful for user: {}", user.username);
 
     let response = LoginResponse {
         token,
@@ -131,7 +186,7 @@ pub async fn get_user_info(
     State(app_state): State<AppState>,
     axum::Extension(claims): axum::Extension<Claims>, // This will be injected by the auth middleware
 ) -> Result<Json<ApiResponse<UserInfo>>, StatusCode> {
-    println!("🔍 Getting user info for: {}", claims.user_id());
+    tracing::info!("🔍 Getting user info for: {}", claims.user_id());
 
     // Get user roles from RBAC system
     let roles = app_state.rbac.get_user_roles(claims.user_id()).await;
@@ -155,7 +210,7 @@ pub async fn get_user_info(
 /// Logout endpoint (for completeness - JWT tokens can't be revoked easily)
 /// In production, you might maintain a token blacklist
 pub async fn logout() -> Json<ApiResponse<()>> {
-    println!("👋 User logged out");
+    tracing::info!("👋 User logged out");
     
     // Note: JWTs are stateless, so we can't truly "logout" without maintaining
     // a blacklist or using short-lived tokens with refresh tokens
@@ -171,12 +226,9 @@ pub async fn auth_health(State(app_state): State<AppState>) -> Json<ApiResponse<
         "authentication_enabled": app_state.jwt_keys.config.enabled,
         "jwt_issuer": app_state.jwt_keys.config.jwt_issuer,
         "jwt_expiry_hours": app_state.jwt_keys.config.jwt_expiry_hours,
-        "available_demo_users": ["admin", "user", "demo"],
-        "demo_credentials": {
-            "admin": "admin123",
-            "user": "user123", 
-            "demo": "demo123"
-        }
+        "password_hash_cost": app_state.jwt_keys.config.password_hash_cost,
+        "available_demo_users": ["admin", "user", "demo", "developer"],
+        "security_note": "Passwords are now securely hashed with bcrypt"
     });
 
     Json(ApiResponse::success(
@@ -200,21 +252,45 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_user_password_verification() {
-        let user = User::new("test", "testuser", "password123");
-        assert!(user.verify_password("password123"));
-        assert!(!user.verify_password("wrong_password"));
+    #[tokio::test]
+    async fn test_password_hashing_and_verification() {
+        let password = "test_password_123";
+        let hash = hash_password(password, 8).await.unwrap(); // Lower cost for tests
+        
+        // Verify correct password
+        assert!(verify_password(password, &hash).await.unwrap());
+        
+        // Verify incorrect password
+        assert!(!verify_password("wrong_password", &hash).await.unwrap());
     }
 
-    #[test]
-    fn test_demo_users_creation() {
-        let users = get_demo_users();
+    #[tokio::test]
+    async fn test_user_password_verification_bcrypt() {
+        let user = User::new("test", "testuser", "password123", 8).await.unwrap();
+        
+        assert!(user.verify_password("password123").await.unwrap());
+        assert!(!user.verify_password("wrong_password").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_demo_users_creation() {
+        let users = get_demo_users(8).await.unwrap(); // Lower cost for tests
         assert_eq!(users.len(), 4);
         assert!(users.iter().any(|u| u.username == "admin"));
         assert!(users.iter().any(|u| u.username == "user"));
         assert!(users.iter().any(|u| u.username == "demo"));
         assert!(users.iter().any(|u| u.username == "developer"));
+    }
+
+    #[tokio::test]
+    async fn test_bcrypt_error_handling() {
+        // Test invalid hash format
+        let result = verify_password("test", "invalid_hash").await;
+        assert!(result.is_err());
+        
+        // Test invalid cost (too high)
+        let result = hash_password("test", 32).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/testing-api.http
+++ b/testing-api.http
@@ -149,6 +149,10 @@ Content-Type: application/json
 }
 
 ### Make api call
+GET http://localhost:10000/status/200
+
+
+### Make api call
 POST http://localhost:10000/status/200
 
 ### Make api call


### PR DESCRIPTION
  - Update bcrypt dependency to 0.17.0
  - Implement async password hashing/verification with spawn_blocking
  - Replace plain text demo passwords with secure bcrypt hashes
  - Add AuthError enum for proper error handling
  - Remove credential exposure from auth health endpoint
  - Add comprehensive tests for bcrypt operations
  - Use tracing instead of println for security logging

Fixes #16 - Critical security vulnerability resolved